### PR TITLE
Switch to Adafruit_GPIO for cross-platform compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ cache: pip
 
 install:
   - pip install -r requirements.txt
-  - pip install -r test-requirements.txt
   - pip install flake8
-  - pip uninstall -y RPi.GPIO
 script:
   - flake8 rfdevices/
   - nosetests tests/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ High level RF library for interacting with common devices.
 
 # Requirements
 * Python 3
-* RPi.GPIO
+* Native GPIO library (see Installation)
 
 # Installation
 Clone this repo locally, then:  
@@ -11,13 +11,33 @@ Clone this repo locally, then:
 pip install rfdevices
 ```
 
+## Native GPIO Library
+For GPIO operations, this library uses [adafruit/Adafruit_Python_GPIO](https://github.com/adafruit/Adafruit_Python_GPIO)
+for compatibility with multiple SoC boards. As a result, you'll need to ensure you manually install your platform's
+GPIO library.
+
+If you have a Raspberry Pi:
+```bash
+pip install RPi.GPIO
+```
+See [RPi.GPIO on Sourceforge](https://sourceforge.net/p/raspberry-gpio-python/wiki/Home/) for more information. 
+
+If you have a Beaglebone Black:
+```bash
+pip install Adafruit_BBIO
+```
+See [adafruit/adafruit-beaglebone-io-python](https://github.com/adafruit/adafruit-beaglebone-io-python) for more information.
+
+If you have an Intel (e.g. Galileo, Edison) board, follow the instructions at
+[intel-iot-devkit/mraa](https://github.com/intel-iot-devkit/mraa).
+
+
 # Usage
 After installing, the `rfsend` tool will be available in your `PATH`.
 
 Here's an example of sending a command to a UC7070T (Harbor Breeze) fan to toggle the light on/off:
 ```bash
-# GPIO pin 23
-# Fan dipswitches are 1101
+# GPIO pin 23 / fan dipswitch set to 1101
 rpi-rftx -g 23 -t uc7070t -b 111010000001
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-RPi.GPIO
+Adafruit-GPIO

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     author='Milas Bowman',
     author_email='milasb@gmail.com',
-    description='Sending RF signals with low-cost GPIO modules on a Raspberry Pi',
+    description='Control household RF devices with low-cost GPIO modules',
     long_description=readme,
     url='https://github.com/milas/rfdevices',
     license='BSD',
@@ -39,6 +39,8 @@ setup(
         'rpi',
         'raspberry',
         'raspberry pi',
+        'adafruit',
+        'beaglebone',
         'rf',
         'gpio',
         'radio',
@@ -47,7 +49,7 @@ setup(
         '315',
         '315mhz'
     ],
-    install_requires=['RPi.GPIO'],
+    install_requires=['Adafruit-GPIO'],
     scripts=['scripts/rfsend'],
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     package_data={

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,0 @@
-mock-import

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,6 @@
 import unittest
 
-from mock_import import mock_import
-
-with mock_import():
-    from rfdevices import BasebandValue, Protocol, PulseOrder, config
+from rfdevices import BasebandValue, Protocol, PulseOrder, config
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2,10 +2,10 @@ import unittest
 
 from unittest import mock
 
-from mock_import import mock_import
+from Adafruit_GPIO import GPIO
 
-with mock_import():
-    from rfdevices import BasebandValue, Protocol, PulseOrder, RFDevice
+from rfdevices import BasebandValue, Protocol, PulseOrder, RFDevice
+
 
 test_protocol = Protocol(pulse_length=1,
                          pulse_order=PulseOrder.LowHigh,
@@ -17,12 +17,26 @@ test_protocol = Protocol(pulse_length=1,
 
 
 class TestDevice(unittest.TestCase):
-    @mock.patch.object(RFDevice, 'cleanup')
-    def test_ctx_manager(self, cleanup_mock):
-        device = RFDevice(gpio=mock.MagicMock())
+    @mock.patch('rfdevices.device.GPIO.get_platform_gpio', return_value=mock.MagicMock(spec=GPIO.BaseGPIO))
+    def test_auto_gpio(self, platform_mock):
+        device = RFDevice(pin=16)
+
+        self.assertEqual(device.pin, 16)
+        self.assertIsInstance(device.gpio, GPIO.BaseGPIO)
+        self.assertIsInstance(device.gpio, mock.MagicMock)
+
+    def test_ctx_manager(self):
+        gpio = mock.MagicMock(spec=GPIO.BaseGPIO)
+        device = RFDevice(pin=8, gpio=gpio)
+
+        self.assertFalse(gpio.setup.called)
+        self.assertFalse(gpio.cleanup.called)
         self.assertFalse(device.tx_enabled)
 
         with device:
+            self.assertEqual(gpio.setup.call_count, 1)
+            self.assertFalse(gpio.cleanup.called)
             self.assertTrue(device.tx_enabled)
 
-        self.assertEqual(cleanup_mock.call_count, 1)
+        self.assertEqual(gpio.setup.call_count, 1)
+        self.assertEqual(gpio.cleanup.call_count, 1)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,9 +1,6 @@
 import unittest
 
-from mock_import import mock_import
-
-with mock_import():
-    from rfdevices.protocol import BasebandValue, Protocol, PulseOrder
+from rfdevices.protocol import BasebandValue, Protocol, PulseOrder
 
 
 class TestProtocol(unittest.TestCase):


### PR DESCRIPTION
This should allow the library to work on the Raspberry Pi, Beaglebone Black, and Intel Edison/Galileo boards now.

It's only been tested on the RPi3 at the moment. The main motivation
for switching was actually that the Adafruit library provides an
abstraction around the `RPi.GPIO` library, which makes testing/mocking
easier instead of mucking with mocking imports.